### PR TITLE
Docker container + FFmpeg + vid.stab support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+media_drive/**/*
+
+.git/
+
+README.md
+
+.docker-installation
+.build-docker

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+.DS_Store
+
 .lock
 resized
 *.mp4
+
+media_drive/*
+!media_drive/.gitkeep
+
+# Vim
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ media_drive/*
 
 # Vim
 *.swp
+
+# Makefile builds
+.build-docker
+.docker-installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu
+
+MAINTAINER Hector hector@hectorleiva.com
+
+WORKDIR /app
+
+COPY . ./
+
+RUN apt-get update -qq && \
+    apt-get install -y \
+		wget \
+        apt-utils \
+        build-essential \
+        sudo \
+        git-core \
+        cmake \
+        yasm \
+        nasm \
+        automake \
+        autoconf \
+        libtool \
+        pkg-config \
+        texinfo \
+        libass-dev \
+        libcurl4-openssl-dev \
+        libavcodec-extra57 \
+        libx264-dev \
+        intltool \
+        libxml2-dev \
+        libgtk2.0-dev \
+        libnotify-dev \
+        libglib2.0-dev \
+        libevent-dev \
+        zlib1g-dev \
+        checkinstall
+
+SHELL ["/bin/bash", "-c", "source setup.sh"]

--- a/Makefile
+++ b/Makefile
@@ -15,21 +15,16 @@ CYAN_COLOR=\x1b[36m
 WHITE_COLOR=\x1b[37m
 RESET_COLOR=\x1b[0m
 
-ifndef HACK_THE_DEEP_IMAGES_PATH
-	HACK_THE_DEEP_IMAGES_PATH ?= $(shell bash -c 'read -p "Path to raw images: " pwd; echo $$pwd')
-endif
-
-RESIZE_DEPENDENCY_LOCK_FILE = .lock/.resize-dependencies
-RESIZE_LOCK_FILE = .lock/.resize
-CONVERT_TO_VIDEO_LOCK_FILE = .lock/.convert-to-video
-STABILIZE_VIDEO_DEPENDENCY_LOCK_FILE = .lock/.stabilize-video
+# Docker Commands
+CURRENT_DIR=$(shell pwd)
+DOCKER_IMAGE_NAME="paint_the_ocean"
+DOCKER_CONTAINER_NAME="pto"
+HOST_VOLUME="media_drive"
 
 RESIZE_IMAGE_DIRECTORY = ./resized
 RESIZE_OUTPUT_IMAGE = resized/output-%04d.jpg
-RESIZE_INPUT_IMAGE = $(HACK_THE_DEEP_IMAGES_PATH)/img-%04d.JPG
 
 CONVERT_TO_VIDEO_FILE = scope_rip_1.mp4
-
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -37,55 +32,27 @@ help:
 all: resize convert-to-video stabilize-video ## Resize images, convert to video, and stabilize
 clean: resize-clean convert-to-video-clean stabilize-video-clean ## Clean all temp files and unlock all commands
 
-## Main Steps
-resize: install-ffmpeg ## Resize images to a standardized size
-ifeq (,$(wildcard $(RESIZE_IMAGE_DIRECTORY)))
-	@mkdir $(RESIZE_IMAGE_DIRECTORY)
-endif
-ifeq (,$(wildcard $(RESIZE_LOCK_FILE)))
-	ffmpeg -i $(RESIZE_INPUT_IMAGE) -vf scale=2000:1500 $(RESIZE_OUTPUT_IMAGE)
-	@touch $(RESIZE_LOCK_FILE)
-else
-	@echo "Skipping resize."
-endif
+.PHONY: start
+start: .docker-installation .build-docker
 
-convert-to-video: install-ffmpeg ## Convert images to a video
-ifeq (,$(wildcard $(CONVERT_TO_VIDEO_LOCK_FILE)))
-	ffmpeg -r 24 -f image2 -s 1000x750 -i $(RESIZE_OUTPUT_IMAGE) -vcodec libx264 -crf 25 -pix_fmt yuv420p $(CONVERT_TO_VIDEO_FILE)
-	@touch $(CONVERT_TO_VIDEO_LOCK_FILE)
-else
-	@echo "Skipping converting to video."
-endif
+.docker-installation:
+	./check-docker.sh && touch $@
 
-stabilize-video: install-docker ## Stablize video
+.build-docker:
+	docker build -t ${DOCKER_IMAGE_NAME} . && \
+		touch $@ && \
+			docker run --name ${DOCKER_CONTAINER_NAME} \
+			-v ${CURRENT_DIR}/${HOST_VOLUME}:/app/${HOST_VOLUME} \
+			-it ${DOCKER_IMAGE_NAME} \
+			/bin/bash
 
-## Helpers
-install-ffmpeg: ## Install ffmpeg
-ifeq (,$(wildcard $(RESIZE_DEPENDENCY_LOCK_FILE)))
-	brew install ffmpeg
-	@touch $(RESIZE_DEPENDENCY_LOCK_FILE)
-else
-	@echo "Skipping resize dependency download."
-endif
+.PHONY: destroy
+destroy:
+	docker rm ${DOCKER_CONTAINER_NAME} && \
+	docker rmi ${DOCKER_IMAGE_NAME} && \
+	rm -f .build-docker
 
-install-docker: ## Install docker
-ifeq (,$(wildcard $(STABILIZE_VIDEO_DEPENDENCY_LOCK_FILE)))
-	brew install docker docker-compose docker-machine xhyve docker-machine-driver-xhyve
-	@touch $(STABILIZE_VIDEO_DEPENDENCY_LOCK_FILE)
-else
-	@echo "Skipping stabilize video dependency download."
-endif
-
-resize-clean: ## Remove resize directory and unlock resizing
-	@echo "Cleaning up after resizing..."
-	rm -r $(RESIZE_IMAGE_DIRECTORY)
-	@rm $(RESIZE_LOCK_FILE)
-
-convert-to-video-clean: ## Unlock convert to video
-	@echo "Cleaning up after converting to video..."
-	@rm $(CONVERT_TO_VIDEO_FILE)
-	@rm $(CONVERT_TO_VIDEO_LOCK_FILE)
-
-stabilize-video-clean: ## Unlock video stabilization
-	@echo "Cleaning up after stabilizing video..."
-	@rm $(STABILIZE_VIDEO_DEPENDENCY_LOCK_FILE)
+.PHONY: enter
+enter: .build-docker
+	docker start ${DOCKER_CONTAINER_NAME} && \
+		docker attach ${DOCKER_CONTAINER_NAME}

--- a/README.md
+++ b/README.md
@@ -151,3 +151,73 @@ The analysis happens in 3 steps:
         x, y, w, h = cv2.boundingRect(conts[i])
         cv2.rectangle(img, (x, y), (x+w, y+h), (0, 0, 255))
 ```
+
+## Post-Hackathon Improvements
+
+Hector went ahead and created an isolated Docker container that will process all the photo/video work as listed above. Here are the steps for anyone starting out with this project:
+
+0. Clone this repository into your local machine
+```
+git clone git@github.com:HackTheDeep/paint-the-ocean.git
+```
+
+1. Make sure you have Docker installed on your machine: https://docs.docker.com/docker-for-mac/install/ | This needs to be installed ahead of time before we can truly start anything.
+
+2. You will notice an empty directory called `media_drive/` for this project. This directory is where all the image processing will occur and it'll be our volume.
+
+3. Copy over the images that we will be processing into the `media_drive/`. The images should be in a folder/directory, and every image should be a JPG image. If they are any other format, this process won't work for now.
+
+4. 
+
+*The following is all automated and will take some time to build on your machine.*
+
+```
+make start
+```
+
+This will immediately start building out the Docker container. It will create a container on your machine, install everything nescessary to do all the image processing work, and you will immediately be pushed into this Docker container after it is done installing.
+
+5. You should now be inside the Docker container.
+
+This environment has all of the necessary software you'll need to be able to process your images to render a stablized video that you will need to use to then run the Python OpenCV program against.
+
+If you type out `ls -la`, you should see all of the same folders that were within the repoistory you just cloned with a few additions like `libs/` for example.
+
+Run the command `source setup.sh` to finish setting up the container properly.
+
+6. Remember where you placed your images, we will be referencing that location to process the following scripts.
+
+You can double-check where they are by typing `ls -la media_drive/` and locate them that way from inside the Docker container
+
+7. Execute the following, making sure that you've replaced `<images-folder-name-here>` with the location of where they are within the `media_drive/`. We are looking for the folder that contains just the images themselves.
+```
+./convert_images_to_stablized_video.sh media_drive/<image-folder-name-here>/<all-image-files-here>
+```
+
+8. The script will be excuting the following:
+`0_rename.sh` - Makes sure that if for any chance the files have `.JPG` named in their extension OR `.JPEG` - that they are transformed to `.jpg` to make it easier for the work later on.
+
+`1_resizeimages.sh` - Makes sure that all the images are halved in size. The images we were dealing with during the hackathon were too high in resolution to be able to process the video stablization and OpenCV work later on.
+This creates a folder within `media_drive/resized` that will contain all of the resized images in sequencial order.
+
+`2_convertvideo.sh` - Converts the sequence of images that have been resized into a single video, this video will be in `media_drive/videos` and called something like `converted_images_to_video` and have a timestamp of when this was accomplished.
+
+`3_stablizevideo.sh` - Will take the video entitled `converted_images_to_video` from the `media_drive` and stablizes it. The stablized video will exist within the `media_drive` and be called something like `clip-stablized`.
+
+9. After this is done, you should now be able to access the stablized video from within the `media_drive/videos`. You will now reference this video for the OpenCV processing.
+
+10. You can now exist this container by typing `exit` at any time. The container will exit as well and "turn off"
+
+11. If for any reason you need to re-enter the container to do additional work, you can type
+```
+make enter
+```
+
+and this should restart the container and you'll jump into it as before
+
+12. Once you feel like all the work for image/video stablization has been completed, feel free to delete this container via the command:
+```
+make destroy
+```
+
+This will completely destroy the container and anything that you've installed within it. This `media_drive/` will be left completely alone and on your system. So any converted images/videos, those will remain on your system as before.

--- a/check-docker.sh
+++ b/check-docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v docker)" ]; then
+    #brew install docker docker-compose docker-machine xhyve docker-machine-driver-xhyve
+    echo "Please make sure you install Docker for mac before proceeding"
+    open https://docs.docker.com/docker-for-mac/install/
+    exit 1
+else
+    exit 0
+fi

--- a/color-detect.py
+++ b/color-detect.py
@@ -7,7 +7,7 @@ import numpy as np
 lowerBound = np.array([0, 170, 90])
 upperBound = np.array([378, 255, 255])
 
-cam = cv2.VideoCapture('final_stablizied_stitched_video.mpg')
+cam = cv2.VideoCapture('media_drive/clip-stablized.mp4')
 kernelOpen = np.ones((5, 5))
 kernelClose = np.ones((20, 20))
 

--- a/convert_images_to_stablized_video.sh
+++ b/convert_images_to_stablized_video.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 1 ] || die "Only the path to the directory of sequential images is required, you provided $# We need something like /path/to/images/"
+
+scripts/0_rename.sh $1
+RESIZE_IMAGES_PATH=$(scripts/1_resizeimages.sh $1)
+CONVERTED_VIDEO_PATH=$(scripts/2_convertvideo.sh $RESIZE_IMAGES_PATH)
+scripts/3_stablizevideo.sh $CONVERTED_VIDEO_PATH

--- a/scripts/0_rename.sh
+++ b/scripts/0_rename.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# A helper script in case any of the files we are trying to work with need to have
+# their file extensions lowercased
+
+for i in *.JPEG;
+do
+    mv "$i" "${i/.JPEG/.jpg}"
+done
+
+for i in *.JPG;
+do
+    mv "$i" "${i/.JPG/.jpg}"
+done

--- a/scripts/1_resizeimages.sh
+++ b/scripts/1_resizeimages.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# Step One:
+#   Resize all the images within a directory to ensure that they are all the same
+#   size and smaller than what the camera was able to capture. We had raw images
+#   that were at least 4k in resolution and that would have taken a long time to
+#   do additionally processing.
+#
+#   After this, all the images are also renamed with a trailing "-0000" number
+#   sequence. This is in order to make it easier to reassemble these images together
+#   using ffmpeg.
+#
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 1 ] || die "Only the path to the directory of sequential images is required, you provided $# We need something like /path/to/images/"
+
+OUTPUT_PATH="/app/media_drive/resized"
+
+./0_rename.sh $1
+
+mkdir -p $OUTPUT_PATH
+
+ffmpeg -pattern_type glob \
+    -i "$1/*.jpg" \
+    -vf "scale=iw/2:ih/2" \
+    $OUTPUT_PATH/output-%04d.jpg
+
+return $OUTPUT_PATH

--- a/scripts/2_convertvideo.sh
+++ b/scripts/2_convertvideo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Step Two:
+#   Taking all the images that were created from Step One, we will assemble
+#   them together and convert them into a video that will be used to restablize.
+#
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 1 ] || die "Only the path to the directory of sequential images is required, you provided $# We need something like /path/to/images/"
+
+current_time=$(date "+%Y.%m.%d-%H.%M.%S")
+
+mkdir -p /app/media_drive/videos/
+
+OUTPUT_PATH="/app/media_drive/videos/converted_images_to_video.${current_time}.mp4"
+
+ffmpeg -r 24 -f image2 \
+    -i "$1/output-%04d.jpg" \
+    -vcodec libx264 \
+    -crf 25 \
+    -pix_fmt yuv420p \
+    ${OUTPUT_PATH}
+
+return $OUTPUT_PATH
+

--- a/scripts/3_stablizevideo.sh
+++ b/scripts/3_stablizevideo.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#
+# Step Three:
+#   After generating the video from Step Two, this will apply all the transformation
+#   and stablization to the video itself and creating a final video. This video
+#   is what will be used for OpenCV for additional processing.
+#
+
+die () {
+    echo >&2 "$@"
+    exit 1
+}
+
+[ "$#" -eq 1 ] || die "Only the path to the input video is required, you provided $#"
+
+mkdir -p /app/media_drive/videos/
+
+# First, we are generating a file that contains the stablization data necessary for the stable version of the video
+ffmpeg -i $1 \
+    -vf vidstabdetect=shakiness=10:accuracy=15:result="transforms.trf" \
+    -f null - && \
+# Second, take the file generated and create a new stablized version of the video
+ffmpeg -i $1 \
+    -vf vidstabtransform=zoom=5:input="transforms.trf" \
+    /app/media_drive/clip-stablizied.mp4 && \
+# Thirdly, delete the transformation data, it is no longer required
+rm /app/transforms.trf

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+cd /app/
+mkdir libs/ && cd libs/
+
+echo "Beginning to install Vid.Stab. A video library used to stablized videos..."
+# Install Vid.Stab for stablization
+git clone https://github.com/georgmartius/vid.stab.git && \
+    cd vid.stab/ && \
+        cmake . && \
+        make -j4 && \
+        make install
+
+# We need to ensure that the shell knows where to find the libraries
+echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64" >> ~/.profile
+echo "export LD_LIBRARY_PATH" >> ~/.profile
+
+echo "Vid.Stab installation was successful (1/2)"
+
+echo "Beginning to install FFmpeg for all video stablization and video creation..."
+
+cd ../ && \
+	wget -O ffmpeg-snapshot.tar.bz2 https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
+	tar xjvf ffmpeg-snapshot.tar.bz2 && \
+	cd ffmpeg && \
+		PATH="$HOME/bin:$PATH" PKG_CONFIG_PATH="$HOME/ffmpeg_build/lib/pkgconfig" ./configure \
+		  --prefix="$HOME/ffmpeg_build" \
+		  --pkg-config-flags="--static" \
+		  --extra-cflags="-I$HOME/ffmpeg_build/include" \
+		  --extra-ldflags="-L$HOME/ffmpeg_build/lib" \
+		  --extra-libs="-lpthread -lm" \
+		  --bindir="$HOME/bin" \
+		  --enable-gpl \
+		  --enable-libvidstab \
+		  --enable-libx264 && \
+		PATH="$HOME/bin:$PATH" make && \
+		make install && \
+		hash -r
+
+# Add FFmpeg into the PATH
+echo "PATH=\"$HOME/bin:$PATH\"" >> ~/.profile
+
+echo "FFmpeg installation was successful (2/2)"
+
+# Success!
+cat << EOM
+Everything seems like it was installed successfully! 🙌
+
+You will now be inserted into the docker container, to return back into it, run:
+
+make enter
+
+and you'll jump back into the container. Good Luck!
+EOM
+
+# Ensure these new options are sourced in the bashrc file
+source ~/.profile
+
+# Return back to the root directory
+cd /app


### PR DESCRIPTION
Reworking the entire Makefile to support installation of all necessary
binaries to occur within the Docker container itself so that the host
system would only be responsible for Docker only.

This means that the installation of `ffmpeg` and binaries
and including the necessary vid.stab (video stablization)
binaries and how they interact are taken care of within the
Docker container only.

The `Makefile` will now only be responsible for starting, entering, and
destroying all aspects of the Docker container itself.

The more important piece of this is that anything that is created within
the Docker container will be avaiable to the host system via the
`media_drive/` Docker volume which is a bi-directional volume mount.
This allows the stablized videos and results of the work to be available on
the host system without much effort.

All the scripts that are now responsible for:
- resizing all images
- creating the video of the images in sequence
- stablize the video and export it out

now exist within the `/scripts` directory and are executed one after
another via a master script located on the root directory via:
`convert_images_to_stablized_video.sh`.

Unfortunately as of this commit, I have not been able to figure out how
to execute `./setup.sh` within the Docker container, so the README
includes instructions on needing to execute this within the Docker
container before anything else can be executed.